### PR TITLE
feat: Improve parsing error message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ serde_json = "1.0.72"
 [dependencies.reqwest]
 version = "0.11.7" 
 default-features = false
-features = ["json", "rustls-tls"]
+features = ["rustls-tls"]

--- a/src/api/station.rs
+++ b/src/api/station.rs
@@ -57,16 +57,17 @@ impl StationApi {
             .append_pair("lng", &lng.to_string())
             .append_pair("rad", &radius.to_string())
             .append_pair("type", "all");
-        let request = self
+        let res_body = self
             .client
             .get(url)
             .send()
             .await
             .map_err(|err| error::TankerkoenigError::RequestError { source: err })?
-            .json::<models::station::AreaNearResponse>()
+            .text()
             .await
-            .map_err(|err| error::TankerkoenigError::ResponseParsingError { source: err })?;
-        Ok(request)
+            .map_err(|err| error::TankerkoenigError::RequestError { source: err })?;
+        serde_json::from_str::<models::station::AreaNearResponse>(&res_body)
+            .map_err(|_| error::TankerkoenigError::ResponseParsingError { body: res_body })
     }
 
     /// Fetch all stations in a radius around the given coordinates that sell a specific kind
@@ -103,16 +104,17 @@ impl StationApi {
             .append_pair("rad", &radius.to_string())
             .append_pair("type", &fuel.to_string())
             .append_pair("sort", &sort.to_string());
-        let request = self
+        let res_body = self
             .client
             .get(url)
             .send()
             .await
             .map_err(|err| error::TankerkoenigError::RequestError { source: err })?
-            .json::<models::station::AreaFuelResponse>()
+            .text()
             .await
-            .map_err(|err| error::TankerkoenigError::ResponseParsingError { source: err })?;
-        Ok(request)
+            .map_err(|err| error::TankerkoenigError::RequestError { source: err })?;
+        serde_json::from_str::<models::station::AreaFuelResponse>(&res_body)
+            .map_err(|_| error::TankerkoenigError::ResponseParsingError { body: res_body })
     }
 
     /// Fetch informations about a certain station by id.
@@ -135,15 +137,16 @@ impl StationApi {
         let id = id.as_ref();
         let mut url = construct_base_url(&self.options.api_key, Some("json/detail.php"))?;
         url.query_pairs_mut().append_pair("id", id);
-        let request = self
+        let res_body = self
             .client
             .get(url)
             .send()
             .await
             .map_err(|err| error::TankerkoenigError::RequestError { source: err })?
-            .json::<models::station::DetailsResponse>()
+            .text()
             .await
-            .map_err(|err| error::TankerkoenigError::ResponseParsingError { source: err })?;
-        Ok(request)
+            .map_err(|err| error::TankerkoenigError::RequestError { source: err })?;
+        serde_json::from_str::<models::station::DetailsResponse>(&res_body)
+            .map_err(|_| error::TankerkoenigError::ResponseParsingError { body: res_body })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,20 +12,19 @@ pub enum TankerkoenigError {
     },
     /// Something went wrong during the parsing
     /// of the tankerkoenig api response.
-    #[error("Failed to parse json response")]
+    #[error("Failed to parse json response: '{body}'")]
     ResponseParsingError {
-        /// Error source
-        #[source]
-        source: reqwest::Error,
+        /// Response body that could not be parsed
+        body: String,
     },
-    /// Somehing went wrong during header construction
+    /// Something went wrong during header construction
     #[error("Failed to construct http header")]
     HeaderConstruction {
         /// Error source
         #[from]
         source: reqwest::header::InvalidHeaderValue,
     },
-    /// Somthing went wrong during http client creation
+    /// Something went wrong during http client creation
     #[error("Failed to create http client")]
     ClientConstruction {
         /// Error source


### PR DESCRIPTION
This PR adds the response json body as string to the parsing error so the user can get an idea why the parsing failed.


Close #9

- feat(error): Add response body to parsing error
- feat(api): Throw parsing error with response body as string
- refactor(cargo): Remove json feature from reqwest as not used anymore
