### PR TITLE
chore: Run test workflow as matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,18 @@ on:
 jobs:
   clippy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_version:
+          - stable
+          - beta
+          - nightly
     steps:
       - uses: actions/checkout@v2
       - name: Setup Rust with clippy
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust_version }}
           profile: minimal
           override: true
           components: clippy
@@ -27,12 +33,18 @@ jobs:
           args: -- -D warnings
   format:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_version:
+          - stable
+          - beta
+          - nightly
     steps:
       - uses: actions/checkout@v2
       - name: Setup Rust with rustfmt
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust_version }}
           profile: minimal
           override: true
           components: rustfmt
@@ -43,12 +55,18 @@ jobs:
           args: --all -- --check
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_version:
+          - stable
+          - beta
+          - nightly
     steps:
       - uses: actions/checkout@v2
       - name: Setup Rust with rustfmt
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust_version }}
           profile: minimal
           override: true
       - name: Run tests
@@ -58,12 +76,18 @@ jobs:
   build_test:
     if: inputs.build_test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust_version:
+          - stable
+          - beta
+          - nightly
     steps:
       - uses: actions/checkout@v2
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust_version }}
       - name: Build binary
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This PR executes the test workflow against stable, beta and nightly rust.

Close #10
