### PR TITLE
refactor: Remove strum macro dependency and adjust imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,16 @@ keywords = ["api-wrapper", "tankerkoenig", "api"]
 publish = false
 
 [dependencies]
-strum = "0.24"
-strum_macros = "0.24"
 thiserror = "1.0.30"
-serde = {version = "1.0.131", features = ["derive"]}
 serde_json = "1.0.72"
+
+[dependencies.serde]
+version = "1.0.131"
+features = ["derive"]
+
+[dependencies.strum]
+version = "0.24"
+features = ["derive"]
 
 [dependencies.reqwest]
 version = "0.11.7" 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tankerkoenig"
 author = "Jontze <dev@jontze.com>"
 description = "API wrapper for the tankerkoenig api"
-version = "0.1.0"
+version = "0.1.0-rc.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://github.com/jontze/tankerkoenig-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ documentation = "#"
 readme = "README.md"
 keywords = ["api-wrapper", "tankerkoenig", "api", "fuel", "germany", "fuel prices"]
 categories = ["API bindings"]
+exclude = [
+    ".github/",
+]
 
 [dependencies]
 thiserror = "1.0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tankerkoenig"
+author = "Jontze <dev@jontze.com>"
 description = "API wrapper for the tankerkoenig api"
 version = "0.1.0"
 edition = "2021"
@@ -8,8 +9,8 @@ homepage = "https://github.com/jontze/tankerkoenig-rs"
 repository = "https://github.com/jontze/tankerkoenig-rs"
 documentation = "#"
 readme = "README.md"
-keywords = ["api-wrapper", "tankerkoenig", "api"]
-publish = false
+keywords = ["api-wrapper", "tankerkoenig", "api", "fuel", "germany", "fuel prices"]
+categories = ["API bindings"]
 
 [dependencies]
 thiserror = "1.0.30"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,9 @@
 
 #[macro_use]
 extern crate serde;
+extern crate reqwest;
 extern crate serde_json;
 extern crate strum;
-#[macro_use]
-extern crate strum_macros;
-extern crate reqwest;
 #[macro_use]
 extern crate thiserror;
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -9,7 +9,7 @@ pub use price::PriceResponse;
 pub use station::{AreaFuelResponse, AreaNearResponse, DetailsResponse};
 
 /// Enum of all supported fuel types
-#[derive(EnumString, Display, PartialEq, Debug, Eq, Clone, PartialOrd, Ord)]
+#[derive(strum::EnumString, strum::Display, PartialEq, Debug, Eq, Clone, PartialOrd, Ord)]
 pub enum Fuel {
     /// Super95 or E5 and serialized to `e5`
     #[strum(serialize = "e5")]
@@ -23,7 +23,7 @@ pub enum Fuel {
 }
 
 /// Enum of supported sorting logic
-#[derive(EnumString, Display, PartialEq, Debug, Eq, Clone, PartialOrd, Ord)]
+#[derive(strum::EnumString, strum::Display, PartialEq, Debug, Eq, Clone, PartialOrd, Ord)]
 pub enum Sort {
     /// Sort by price from lowest to highest price and
     /// will serialize to `price`


### PR DESCRIPTION
This PR adjusts the usage of the strum lib so there are not 2 dependencies linked to the lib.

Additionally some information was added to the cargo manifest.