### PR TITLE
chore(workflow): Publish cargo release on github release

### DIFF
--- a/.github/workflows/cargo_publish.yml
+++ b/.github/workflows/cargo_publish.yml
@@ -1,0 +1,29 @@
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        type: string
+        required: true
+    secrets:
+      TOKEN:
+        required: true
+
+jobs:
+  publish_crate:
+    name: Publish crate ${{ inputs.tag_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.tag_name }}
+      - name: Install rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          default: true
+      - name: Publish crate
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Release
+on:
+  release:
+    types:
+      - "published"
+
+jobs:
+  release_test:
+    name: Test
+    uses: ./.github/workflows/test.yml
+  cargo_publish:
+    name: Publish
+    uses: ./.github/workflows/cargo_publish.yml
+    with:
+      tag_name: ${{ github.event.release.tag_name }}
+    secrets:
+      TOKEN: ${{ secrets.CARGO_TOKEN }}


### PR DESCRIPTION
This PR creates a release workflow for crates.io on each github release.

Close #13