### PR TITLE
feat: Throw error if prices for more than 10 stations requested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,8 @@ features = ["derive"]
 version = "0.11.7" 
 default-features = false
 features = ["rustls-tls"]
+
+[dev-dependencies.tokio]
+version = "1.19.2"
+features = ["rt", "macros"]
+

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,4 +34,10 @@ pub enum TankerkoenigError {
     /// Failed to parse the request url
     #[error("Failed to construct the url")]
     UrlConstruction,
+    /// Informations for too many stations were requested
+    #[error("The request is not possible as to many ids were given. Max: {max}")]
+    TooManyStations {
+        /// Maximum number of simultaneously requested stations exceeded
+        max: usize,
+    },
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -52,6 +52,20 @@ pub mod price {
         }
         ids_string
     }
+
+    pub fn count_ids<I>(ids: I) -> (usize, Vec<I::Item>)
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str> + Display,
+    {
+        let mut counted_ids = Vec::new();
+        let mut counter = 0_usize;
+        for item in ids.into_iter() {
+            counted_ids.push(item);
+            counter += 1;
+        }
+        (counter, counted_ids)
+    }
 }
 
 pub mod station {}
@@ -90,5 +104,16 @@ mod price_test {
         let ids = vec!["123", "456"];
         let ids_string = format_ids_string(ids);
         assert_eq!(ids_string, "123,456");
+    }
+
+    #[test]
+    fn should_count_and_return_ids() {
+        let dummy_ids = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"];
+        let (count, counted_ids) = count_ids(dummy_ids);
+        assert_eq!(count, 11);
+        assert_eq!(counted_ids.len(), 11);
+        for (index, entry) in counted_ids.into_iter().enumerate() {
+            assert_eq!(entry, dummy_ids[index]);
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a new error that will be thrown if the user fetches the prices for more than 10 stations at once. This is due to a limitation of the tankerkoenig api. The api allows only 10 stations at one and ignores every additional station. Since this unintended behaviour and confusing for the user, the function will now throw an error in such a case and restrict the user to request only 10 stations at once.

Related to #7 