### PR TITLE
Release `0.2.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.68.0" # MSRV
+          - "1.70.0" # MSRV
     steps:
       - uses: actions/checkout@v4
       - name: Setup Cache for Rust
@@ -50,7 +50,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.68.0" # MSRV
+          - "1.70.0" # MSRV
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
@@ -70,7 +70,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.68.0" # MSRV
+          - "1.70.0" # MSRV
     steps:
       - uses: actions/checkout@v4
       - name: Setup Cache for Rust
@@ -92,7 +92,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - "1.68.0" # MSRV
+          - "1.70.0" # MSRV
     steps:
       - uses: actions/checkout@v4
       - name: Setup Cache for Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tankerkoenig"
 author = "Jontze <dev@jontze.com>"
 description = "API wrapper for the tankerkoenig api"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.70.0"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ author = "Jontze <dev@jontze.com>"
 description = "API wrapper for the tankerkoenig api"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.68.0"
+rust-version = "1.70.0"
 license = "MIT"
 homepage = "https://github.com/jontze/tankerkoenig-rs"
 repository = "https://github.com/jontze/tankerkoenig-rs"
@@ -14,6 +14,7 @@ keywords = ["api-wrapper", "tankerkoenig", "api", "fuel"]
 categories = ["api-bindings"]
 exclude = [
     ".github/",
+    "test"
 ]
 
 [dependencies]
@@ -36,7 +37,7 @@ features = ["rustls-tls"]
 
 [dev-dependencies]
 futures = "0.3.28"
-mockall = "0.11.4"
+mockall = "0.12.1"
 wiremock = "0.5.19"
 
 [dev-dependencies.tokio]


### PR DESCRIPTION
This PR prepares the `0.2.0` release. This is a maintenance release mostly with dependency updates. Beside of that the MSRV was bumped from 1.68.0 to 1.70.0.